### PR TITLE
fix: 認証ミドルウェアの保護範囲を拡大 #82

### DIFF
--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,7 +1,9 @@
+/** 認証が必要なパスのプレフィックス一覧 */
+const PROTECTED_PATH_PREFIXES = ["/board", "/list", "/analytics", "/note", "/admin"];
+
 export default defineNuxtRouteMiddleware((to) => {
   const user = useSupabaseUser();
   const loading = useState("auth-loading", () => true);
-  console.log("middleware:", to.path, to.query);
 
   // ?code=を検知しgoogle認証完了後にリダイレクト
   if (to.path === "/" && to.query.code) {
@@ -9,10 +11,11 @@ export default defineNuxtRouteMiddleware((to) => {
   }
 
   // 未ログインユーザーが認証が必要なページへのアクセスしたらログイン画面へ
-  if (to.path === "/board" || to.path === "/list") {
-    if (!user.value) {
-      return navigateTo("/auth");
-    }
+  const isProtected = PROTECTED_PATH_PREFIXES.some((prefix) =>
+    to.path.startsWith(prefix),
+  );
+  if (isProtected && !user.value) {
+    return navigateTo("/auth");
   }
 
   // 認証済みユーザーの認証ページへのアクセスしたらボードビューへ


### PR DESCRIPTION
## Summary
- 認証ミドルウェアの保護対象パスに `/analytics`, `/note`, `/admin` を追加
- 完全一致(`===`)からプレフィックスマッチ(`startsWith`)に変更し、ネストルートも保護
- デバッグ用 `console.log` を削除

close #82

## Test plan
- [ ] 未認証状態で `/analytics`, `/note/xxx`, `/admin` にアクセスし、`/auth` にリダイレクトされることを確認
- [ ] 認証済みで各ページに正常アクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)