### PR TITLE
fix: 管理者権限チェックのエラー判定を statusCode で判定 #83

### DIFF
--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -175,7 +175,8 @@ const refresh = async () => {
     usersData.value = data.value ?? [];
     isAdmin.value = true;
   } catch (err) {
-    if (err instanceof Error && err.message === "Forbidden") {
+    const statusCode = (err as { statusCode?: number }).statusCode;
+    if (statusCode === 403) {
       isAdmin.value = false;
       adminCheckError.value = null;
       usersData.value = [];


### PR DESCRIPTION
## Summary
- `err.message === "Forbidden"` → `statusCode === 403` に変更
- エラーオブジェクトの形式に依存しない安定した判定に修正

close #83

## Test plan
- [ ] 管理者でないユーザーで `/admin` にアクセスし、権限不足メッセージが表示されることを確認
- [ ] 管理者ユーザーで正常にデータが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)