### PR TITLE
fix: Gemini API に入力バリデーションを追加 #85

### DIFF
--- a/server/api/gemini/chat.post.ts
+++ b/server/api/gemini/chat.post.ts
@@ -56,6 +56,21 @@ const handler = async (event: H3Event): Promise<{ text: string }> => {
   const body = (await readBody(event)) as GeminiChatRequest;
   const { history, message, prompt, model: userModel } = body;
 
+  // 入力文字列の長さ制限
+  const MAX_MESSAGE_LENGTH = 10000;
+  if (message && message.length > MAX_MESSAGE_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `メッセージは${MAX_MESSAGE_LENGTH}文字以内にしてください`,
+    });
+  }
+  if (prompt && prompt.length > MAX_MESSAGE_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `プロンプトは${MAX_MESSAGE_LENGTH}文字以内にしてください`,
+    });
+  }
+
   const client = new GoogleGenAI({ apiKey });
 
   // Default to gemini-2.5-flash if not specified


### PR DESCRIPTION
## Summary
- `message` と `prompt` に10,000文字の長さ制限を追加
- 超過時は 400 エラーを返す

close #85

## Test plan
- [ ] 通常のメッセージでAIチャットが正常に動作することを確認
- [ ] 10,000文字を超える入力で適切なエラーメッセージが返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)