### PR TITLE
fix: admin テーブルの colspan 不一致を修正 #88

### DIFF
--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -77,7 +77,7 @@
             </thead>
             <tbody class="divide-y divide-gray-100 bg-white">
               <tr v-if="pending">
-                <td colspan="5" class="px-4 py-6">
+                <td colspan="4" class="px-4 py-6">
                   <div
                     class="flex items-center justify-center gap-3 text-gray-500"
                   >
@@ -87,7 +87,7 @@
                 </td>
               </tr>
               <tr v-else-if="users.length === 0">
-                <td colspan="5" class="px-4 py-6 text-center text-gray-500">
+                <td colspan="4" class="px-4 py-6 text-center text-gray-500">
                   表示できるユーザーがありません。
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- `<tbody>` のローディング行・空行の `colspan` を `5` → `4` に修正（`<thead>` のカラム数に合わせた）

close #88

## Test plan
- [ ] `/admin` ページのローディング状態と空データ状態でテーブルレイアウトが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)