### PR TITLE
fix: total_time の型を number に統一 #89

### DIFF
--- a/app/components/analytics/TimeDistribution.vue
+++ b/app/components/analytics/TimeDistribution.vue
@@ -23,21 +23,8 @@ let chart: any = null;
 const getTaskTimeData = () => {
   // 時間データを持つタスクのみ抽出
   const tasksWithTime = props.tasks
-    .filter((task) => {
-      const time = Array.isArray(task.total_time)
-        ? task.total_time[0] || 0
-        : task.total_time || 0;
-      return time > 0;
-    })
-    .sort((a, b) => {
-      const timeA = Array.isArray(a.total_time)
-        ? a.total_time[0] || 0
-        : a.total_time || 0;
-      const timeB = Array.isArray(b.total_time)
-        ? b.total_time[0] || 0
-        : b.total_time || 0;
-      return timeB - timeA; // 降順ソート
-    })
+    .filter((task) => (task.total_time || 0) > 0)
+    .sort((a, b) => (b.total_time || 0) - (a.total_time || 0))
     .slice(0, 10); // 上位10件に絞る
 
   return {
@@ -47,11 +34,7 @@ const getTaskTimeData = () => {
         ? task.title.substring(0, 20) + "..."
         : task.title;
     }),
-    times: tasksWithTime.map((task) => {
-      return Array.isArray(task.total_time)
-        ? task.total_time[0] || 0
-        : task.total_time || 0;
-    }),
+    times: tasksWithTime.map((task) => task.total_time || 0),
   };
 };
 

--- a/app/components/kanban/TodoCard.vue
+++ b/app/components/kanban/TodoCard.vue
@@ -158,7 +158,7 @@ const props = defineProps({
       task_id?: string;
       is_private?: boolean;
       is_finished?: boolean;
-      total_time?: number | number[];
+      total_time?: number;
       is_timing?: boolean;
       tags?: { id: string; name: string; color?: string }[];
       assets?: { id: string }[];

--- a/app/components/list/TableRow.vue
+++ b/app/components/list/TableRow.vue
@@ -542,10 +542,7 @@ const statusColor = computed(() => {
 
 // 時間をフォーマット
 const formattedTime = computed(() => {
-  const totalSeconds = Array.isArray(props.todo.total_time)
-    ? props.todo.total_time[0] || 0
-    : props.todo.total_time || 0;
-  return formatTime(totalSeconds);
+  return formatTime(props.todo.total_time || 0);
 });
 
 /**

--- a/app/components/list/TableUtils.ts
+++ b/app/components/list/TableUtils.ts
@@ -3,17 +3,12 @@ import duration from "dayjs/plugin/duration";
 dayjs.extend(duration);
 
 /**
- * total_time を数値に変換する。
- * @description number | number[] を正規化して返す。
- * @param {number | number[] | undefined} time - Todo の total_time。
- * @returns {number} 正規化した秒数。
+ * total_time を安全に数値として取り出す。
+ * @description undefined を 0 に変換する。
+ * @param {number | undefined} time - Todo の total_time。
+ * @returns {number} 秒数。
  */
-export const extractTotalTime = (
-  time: number | number[] | undefined,
-): number => {
-  if (Array.isArray(time) && time.length > 0) {
-    return time[0] ?? 0;
-  }
+export const extractTotalTime = (time: number | undefined): number => {
   return typeof time === "number" ? time : 0;
 };
 

--- a/app/composables/useTaskTimer.ts
+++ b/app/composables/useTaskTimer.ts
@@ -34,15 +34,12 @@ export const useTaskTimer = () => {
   };
 
   /**
-   * total_time の型ゆれを吸収する。
-   * @description number | number[] から数値を取り出す。
-   * @param {number | number[] | undefined} time - 正規化対象の値。
-   * @returns {number} 正規化した秒数。
+   * total_time を安全に数値として取り出す。
+   * @description undefined を 0 に変換する。
+   * @param {number | undefined} time - 取得対象の値。
+   * @returns {number} 秒数。
    */
-  const extractTotalTime = (time: number | number[] | undefined): number => {
-    if (Array.isArray(time) && time.length > 0) {
-      return time[0] ?? 0;
-    }
+  const extractTotalTime = (time: number | undefined): number => {
     return typeof time === "number" ? time : 0;
   };
 

--- a/app/pages/analytics/index.vue
+++ b/app/pages/analytics/index.vue
@@ -273,12 +273,7 @@ const completedTasks = computed(
   () => filteredTasks.value.filter((task) => task.is_finished).length,
 );
 const totalTimeSpent = computed(() =>
-  filteredTasks.value.reduce((sum, task) => {
-    const time = Array.isArray(task.total_time)
-      ? task.total_time[0] || 0
-      : task.total_time || 0;
-    return sum + time;
-  }, 0),
+  filteredTasks.value.reduce((sum, task) => sum + (task.total_time || 0), 0),
 );
 
 // 最近のタスク

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -29,7 +29,7 @@ export type Todo = {
   is_finished?: boolean;
   user_id?: string;
   updated_at?: string;
-  total_time?: number | number[];
+  total_time?: number;
   is_timing?: boolean;
   tags?: Tag[];
   assets?: TodoAsset[];


### PR DESCRIPTION
## Summary
- `Todo.total_time` の型を `number | number[]` → `number` に統一
- `normalizeTodo` で DB 取得時に配列→数値変換済みのため、各コンポーネントの `Array.isArray` チェックを削除
- `extractTotalTime` の引数型を `number | undefined` に簡略化

### 変更ファイル
- `types/todo.ts` - 型定義変更
- `app/composables/useTaskTimer.ts` - `extractTotalTime` 簡略化
- `app/pages/analytics/index.vue` - 集計ロジック簡略化
- `app/components/analytics/TimeDistribution.vue` - チャートデータ取得簡略化
- `app/components/kanban/TodoCard.vue` - props 型修正
- `app/components/list/TableRow.vue` - フォーマット処理簡略化
- `app/components/list/TableUtils.ts` - `extractTotalTime` 簡略化

close #89

## Test plan
- [ ] タイマー機能が正常に動作することを確認
- [ ] アナリティクスのチャートが正常に表示されることを確認
- [ ] リストビューの作業時間表示が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)