### PR TITLE
fix: timer-guard の confirm() を Nuxt UI モーダルに置き換え #91

### DIFF
--- a/app/plugins/timer-guard.global.ts
+++ b/app/plugins/timer-guard.global.ts
@@ -3,7 +3,7 @@ import type { NavigationGuardNext, RouteLocationNormalized } from "vue-router";
 
 export type TimerNavigationEvent = {
   /** 発行するアクション */
-  action: "stop-timer";
+  action: "stop-timer" | "confirm-navigation";
   /** 対象の Todo ID */
   todoId: string;
   /** 遷移先のパス */
@@ -40,21 +40,13 @@ const plugin = () => {
       const timingTodo = todoStore.todos.find((todo) => todo.is_timing);
 
       if (timingTodo) {
-        // タイマー実行中の場合、確認ダイアログを表示
-        if (
-          confirm(
-            "タイマーが実行中です。タイマーを停止してから移動しますか？",
-          )
-        ) {
-          // 「OK」を選択した場合、タイマー停止イベントを発行して一時的に遷移を阻止
-          timerEvent.emit({
-            action: "stop-timer",
-            todoId: timingTodo.id,
-            destination: to.fullPath,
-          });
-          return next(false);
-        }
-        // 「キャンセル」を選択した場合も遷移を阻止
+        // タイマー実行中の場合、遷移をブロックし確認イベントを発行
+        // コンポーネント側で Nuxt UI のモーダルを表示して対応する
+        timerEvent.emit({
+          action: "confirm-navigation",
+          todoId: timingTodo.id,
+          destination: to.fullPath,
+        });
         return next(false);
       }
     }


### PR DESCRIPTION
## Summary
- ブラウザネイティブ `confirm()` を Nuxt UI の `UModal` に置き換え
- ナビゲーションガードで遷移をブロックし、`confirm-navigation` イベントを発行
- TaskBoard.vue でイベントを受け取り、UIモーダルで確認ダイアログを表示

close #91

## Test plan
- [ ] タイマー稼働中にページ遷移しようとするとモーダルが表示されることを確認
- [ ] 「停止して移動」でタイマー停止後に遷移することを確認
- [ ] 「キャンセル」で遷移がキャンセルされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)