### PR TITLE
fix: onUnmounted をトップレベルに移動 #92

### DIFF
--- a/app/pages/analytics/index.vue
+++ b/app/pages/analytics/index.vue
@@ -309,26 +309,14 @@ onMounted(async () => {
     "completedTasksVisibilityToggle",
     handleCompletedTasksVisibilityToggle,
   );
+});
 
-  // プライベート/パブリックフィルター変更を監視
-  watch(
-    () => todoStore.taskFilter,
-    () => {
-      // ストアのフィルターが変更されたら、データを再フィルタリング
-      console.log(
-        "Todoストアのフィルターが変更されました:",
-        todoStore.taskFilter,
-      );
-    },
+// クリーンアップ
+onUnmounted(() => {
+  window.removeEventListener(
+    "completedTasksVisibilityToggle",
+    handleCompletedTasksVisibilityToggle,
   );
-
-  // クリーンアップ
-  onUnmounted(() => {
-    window.removeEventListener(
-      "completedTasksVisibilityToggle",
-      handleCompletedTasksVisibilityToggle,
-    );
-  });
 });
 
 // ユーティリティ関数


### PR DESCRIPTION
## Summary
- `onUnmounted` を `onMounted` 内のネストからトップレベルに移動
- `console.log` のみだった不要な `watch` を削除

close #92

## Test plan
- [ ] アナリティクスページが正常に表示されることを確認
- [ ] ページ遷移時にイベントリスナーが正しくクリーンアップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)