### PR TITLE
fix: モバイルでAIチャットボタンと新規タスクボタンの重なりを解消

### DIFF
--- a/app/components/ai/AIChat.vue
+++ b/app/components/ai/AIChat.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed bottom-6 right-6 z-50 flex flex-col items-end">
+  <div class="fixed bottom-24 right-6 z-50 flex flex-col items-end md:bottom-6">
     <!-- Chat Window -->
     <transition
       enter-active-class="transition duration-300 ease-out"


### PR DESCRIPTION
AIチャットのフローティングボタンをモバイル時に上方へ移動(bottom-6 → bottom-24)し、
カンバンボードの新規タスク作成ボタンとの重なりを解消。
デスクトップ(md以上)では従来通りの位置を維持。

https://claude.ai/code/session_01AfoRbsqFtQABbsRpHr4GaL