### PR TITLE
Add support for HTML and ZIP file types in asset manager

### DIFF
--- a/app/components/note/AssetManager.vue
+++ b/app/components/note/AssetManager.vue
@@ -539,6 +539,15 @@ const iconForAsset = (asset: TodoAsset) => {
   if (mime.startsWith("audio/")) {
     return "i-heroicons-musical-note";
   }
+  if (mime === "text/html") {
+    return "i-heroicons-code-bracket";
+  }
+  if (
+    mime === "application/zip" ||
+    mime === "application/x-zip-compressed"
+  ) {
+    return "i-heroicons-archive-box";
+  }
   return "i-heroicons-document-duplicate";
 };
 

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -73,7 +73,10 @@ export const TASK_ASSET_ACCEPTED_TYPES = [
   "text/plain",
   "text/markdown",
   "text/csv",
+  "text/html",
   "application/json",
+  "application/zip",
+  "application/x-zip-compressed",
 ] as const;
 
 export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];


### PR DESCRIPTION
## Summary
Extended the asset manager to support HTML and ZIP file types by adding them to the accepted MIME types list and providing appropriate icons for these file formats.

## Key Changes
- Added `text/html` to accepted asset types with code-bracket icon
- Added `application/zip` and `application/x-zip-compressed` to accepted asset types with archive-box icon
- Updated `iconForAsset()` function to return appropriate icons for HTML and ZIP files
- Updated `TASK_ASSET_ACCEPTED_TYPES` constant to include the new MIME types

## Implementation Details
- HTML files now display with the `i-heroicons-code-bracket` icon
- ZIP files (both standard and compressed variants) display with the `i-heroicons-archive-box` icon
- Both MIME type variants for ZIP files are supported to ensure compatibility across different systems

https://claude.ai/code/session_01SXR2n4pm2cCfdVAkufRYiB