### PR TITLE
デザイン全面刷新: カーム・ミニマル (A案) の適用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ dist
 /test-results/
 /playwright-report/
 /blob-report/
-/playwright/.cache/.playwright-mcp/
+/playwright/.cache/
+.playwright-mcp/

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ dist
 /test-results/
 /playwright-report/
 /blob-report/
-/playwright/.cache/
+/playwright/.cache/.playwright-mcp/

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -4,7 +4,7 @@ export default defineAppConfig({
   // Nuxt UI コンポーネント (UButton, UCheckbox, UModal 等) の配色を一括で揃える
   ui: {
     primary: "calm",
-    gray: "gray",
+    gray: "paper",
     button: {
       rounded: "rounded-lg",
     },

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,0 +1,18 @@
+export default defineAppConfig({
+  // カーム・ミニマルのテーマ設定 (issue #112)
+  // primary を calm (tailwind.config.ts で定義した青) に接続し、
+  // Nuxt UI コンポーネント (UButton, UCheckbox, UModal 等) の配色を一括で揃える
+  ui: {
+    primary: "calm",
+    gray: "gray",
+    button: {
+      rounded: "rounded-lg",
+    },
+    card: {
+      rounded: "rounded-card",
+    },
+    modal: {
+      rounded: "rounded-xl",
+    },
+  },
+});

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -2,6 +2,43 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============================================================
+   デザイントークン: カーム・ミニマル (issue #112)
+   固定値のパレットは tailwind.config.ts 側。
+   ここではテーマ(ライト/ダーク)で切り替わる意味論的な値だけを持つ。
+   ============================================================ */
+:root {
+  --app-bg: #f8f8f6;
+  --app-side: #f1f1ed;
+  --app-surface: #ffffff;
+  --app-ink: #1e1f24;
+  --app-muted: #8e8d85;
+  --app-line: #e9e8e2;
+  --app-accent: #3474f0;
+}
+
+.dark {
+  --app-bg: #171613;
+  --app-side: #1c1b17;
+  --app-surface: #201f1b;
+  --app-ink: #eae9e4;
+  --app-muted: #97968d;
+  --app-line: #32312b;
+  --app-accent: #6d97f4;
+}
+
+body {
+  background-color: var(--app-bg);
+  color: var(--app-ink);
+  letter-spacing: 0.01em;
+}
+
+/* タイマー等、数字が並ぶ場所で桁をそろえる */
+.tnum {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
 .markdown-prose {
   max-width: 100%;
   margin: 0 auto;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -39,209 +39,128 @@ body {
   font-feature-settings: "tnum";
 }
 
+/* ============================================================
+   Markdown 表示 (カーム・ミニマル)
+   すべてトークン参照にし、ライト/ダークを自動追従させる
+   ============================================================ */
 .markdown-prose {
   max-width: 100%;
-  margin: 0 auto;
-  color: #657b83;
-  font-family:
-    "Inter",
-    "Hiragino Sans",
-    "Noto Sans JP",
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
-  line-height: 1.6;
+  color: var(--app-ink);
+  font-size: 14px;
+  line-height: 1.75;
   letter-spacing: 0.01em;
-  background-color: #ffffff;
-  padding: 1.25rem;
-  border-radius: 0.6rem;
-  box-shadow: inset 0 0 0 1px rgba(147, 161, 161, 0.2);
 }
 
 .markdown-prose > p {
-  margin-top: 0.75em;
-  margin-bottom: 0.85em;
-  color: #586e75;
-  font-size: 15px;
+  margin: 0.6em 0 0.8em;
+  opacity: 0.92;
 }
 
 .markdown-prose h1,
 .markdown-prose h2,
 .markdown-prose h3 {
-  font-family:
-    "Inter",
-    "Hiragino Sans",
-    "Noto Sans JP",
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
   font-weight: 700;
-  color: #002b36;
-  line-height: 1.3;
-  letter-spacing: 0.015em;
+  color: var(--app-ink);
+  line-height: 1.4;
 }
 
 .markdown-prose h1 {
-  font-size: 20px;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  padding: 0.5em 0.75em;
-  background-color: #22c55e06;
-  border-left: 5px solid #22c55e;
-  font-family:
-    "Hiragino Mincho ProN", "YuMincho", "Noto Serif JP", "Times New Roman",
-    serif;
-  letter-spacing: 0.03em;
+  font-size: 17px;
+  margin: 1.1em 0 0.5em;
+  padding-bottom: 0.35em;
+  border-bottom: 1px solid var(--app-line);
 }
 
 .markdown-prose h2 {
-  font-size: 18px;
-  font-family:
-    "Hiragino Mincho ProN", "YuMincho", "Noto Serif JP", "Times New Roman",
-    serif;
-  margin-top: 1.3em;
-  margin-bottom: 0.75em;
-  padding-left: 0.6em;
-  border-left: 3px solid rgba(147, 161, 161, 0.6);
+  font-size: 15.5px;
+  margin: 1em 0 0.4em;
 }
 
 .markdown-prose h3 {
-  font-size: 16px;
-  margin-top: 1.1em;
-  margin-bottom: 0.6em;
-  color: #073642;
+  font-size: 14.5px;
+  margin: 0.9em 0 0.3em;
 }
 
 .markdown-prose ul,
 .markdown-prose ol {
-  padding-left: 1.75rem;
-  margin: 0.85em 0 1em;
+  margin: 0.4em 0 0.8em;
+  padding-left: 1.4em;
 }
 
 .markdown-prose ul > li,
 .markdown-prose ol > li {
-  padding-left: 0.5em;
-  margin-bottom: 0.3em;
-  color: #586e75;
-  font-size: 15px;
+  margin: 0.25em 0;
+  list-style: revert;
 }
 
-.markdown-prose ul > li::marker {
-  color: #586e75;
-}
-
+.markdown-prose ul > li::marker,
 .markdown-prose ol > li::marker {
-  color: #586e75;
-  font-weight: 600;
+  color: var(--app-muted);
 }
 
 .markdown-prose code {
-  color: #cb4b16;
-  background: #eee8d5;
-  padding: 0.15em 0.45em;
-  border-radius: 0.35rem;
-  font-size: 14px;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  background-color: var(--app-side);
+  border-radius: 5px;
+  padding: 0.15em 0.4em;
+  font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, monospace;
+  font-size: 0.875em;
 }
 
 .markdown-prose > pre {
-  background: #002b36;
-  border-radius: 0.9rem;
-  padding: 1.1rem;
-  margin: 1.2rem -0.4rem;
-  box-shadow: 0 18px 40px rgba(0, 43, 54, 0.35);
-  color: #fdf6e3;
-  font-size: 15px;
-  border: 1px solid rgba(147, 161, 161, 0.25);
+  background-color: var(--app-side);
+  border-radius: 8px;
+  padding: 0.9em 1em;
+  overflow-x: auto;
+  margin: 0.8em 0;
 }
 
 .markdown-prose pre code {
   background-color: transparent;
   padding: 0;
-  color: inherit;
 }
 
 .markdown-prose blockquote {
-  background: #fef3c7;
-  border-left: 4px solid #b58900;
-  border-radius: 0 0.5rem 0.5rem 0;
-  padding: 0.85rem 1.1rem;
-  font-style: italic;
-  color: #855d12;
-  margin: 1rem 0;
-  font-size: 15px;
+  border-left: 3px solid var(--app-line);
+  margin: 0.8em 0;
+  padding: 0.1em 0 0.1em 1em;
+  color: var(--app-muted);
 }
 
 .markdown-prose hr {
-  margin: 1.75rem 0;
   border: none;
-  height: 1px;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(38, 139, 210, 0.45),
-    transparent
-  );
+  border-top: 1px solid var(--app-line);
+  margin: 1.2em 0;
 }
 
 .markdown-prose a {
-  color: #268bd2;
+  color: var(--app-accent);
   text-decoration: none;
-  border-bottom: 1px solid rgba(38, 139, 210, 0.4);
-  transition:
-    color 0.2s ease,
-    border-color 0.2s ease,
-    background 0.2s ease;
 }
 
 .markdown-prose a:hover {
-  color: #2aa198;
-  border-bottom-color: rgba(42, 161, 152, 0.6);
-  background: rgba(38, 139, 210, 0.08);
+  text-decoration: underline;
 }
 
 .markdown-prose table {
   width: 100%;
   border-collapse: collapse;
-  margin: 1.2rem 0;
-  overflow: hidden;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(147, 161, 161, 0.35);
-  background: #fffdf7;
-  box-shadow:
-    inset 0 0 0 1px rgba(147, 161, 161, 0.35),
-    0 12px 25px rgba(147, 161, 161, 0.15);
+  margin: 0.8em 0;
+  font-size: 0.95em;
 }
 
 .markdown-prose th,
 .markdown-prose td {
-  padding: 0.85rem 1rem;
-  border-bottom: 1px solid rgba(147, 161, 161, 0.35);
-  border-right: 1px solid rgba(147, 161, 161, 0.25);
-  font-size: 15px;
+  border: 1px solid var(--app-line);
+  padding: 0.4em 0.7em;
+  text-align: left;
 }
 
 .markdown-prose th {
-  background: linear-gradient(135deg, #eee8d5, #fdf6e3);
+  background-color: var(--app-side);
   font-weight: 600;
-  color: #073642;
-  text-transform: uppercase;
-  font-size: 14px;
-  letter-spacing: 0.05em;
 }
 
-.markdown-prose tbody tr:nth-child(odd) {
-  background-color: rgba(253, 246, 227, 0.65);
-}
-
-.markdown-prose tbody tr:nth-child(even) {
-  background-color: rgba(238, 232, 213, 0.75);
-}
-
-.markdown-prose tbody tr:hover {
-  background-color: rgba(42, 161, 152, 0.08);
+.markdown-prose img {
+  max-width: 100%;
+  border-radius: 8px;
 }

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -164,3 +164,55 @@ body {
   max-width: 100%;
   border-radius: 8px;
 }
+
+/* ============================================================
+   マイクロインタラクション (issue #112 P5)
+   ============================================================ */
+/* チェックボックスを入れた瞬間の小さなポップ */
+@keyframes check-pop {
+  50% {
+    transform: scale(1.18);
+  }
+}
+
+input[type="checkbox"]:checked {
+  animation: check-pop 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* タイマー計測中の穏やかな脈動 */
+@keyframes pulse-soft {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+.pulse-soft {
+  animation: pulse-soft 1.6s ease-in-out infinite;
+}
+
+/* カードのふわっとした出現 */
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+}
+
+.card-in {
+  animation: card-in 0.22s ease-out both;
+}
+
+/* モーション苦手な設定を尊重する */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/app/components/analytics/StatusDistribution.vue
+++ b/app/components/analytics/StatusDistribution.vue
@@ -72,7 +72,7 @@ onMounted(() => {
  */
 const getStatusColor = (status: string) => {
   const statusStyle = STATUS_COLORS[status as keyof typeof STATUS_COLORS];
-  if (!statusStyle) return "#94a3b8"; // デフォルト色
+  if (!statusStyle) return "#aeada5"; // デフォルト色
 
   // iconプロパティからCSS変数の色を抽出（text-green-500 → green-500の色）
   const colorClass = statusStyle.icon.split("-");
@@ -81,13 +81,13 @@ const getStatusColor = (status: string) => {
 
   switch (colorName) {
     case "green":
-      return colorShade === "500" ? "#22c55e" : "#86efac";
+      return colorShade === "500" ? "#fb7185" : "#fecdd3";
     case "blue":
-      return colorShade === "500" ? "#3b82f6" : "#93c5fd";
+      return colorShade === "500" ? "#3474f0" : "#c3d6fb";
     case "gray":
-      return colorShade === "500" ? "#64748b" : "#94a3b8";
+      return colorShade === "500" ? "#aeada5" : "#d8d7d0";
     default:
-      return "#94a3b8"; // デフォルト色
+      return "#aeada5"; // デフォルト色
   }
 };
 
@@ -264,7 +264,7 @@ const initCompletionChart = async () => {
         datasets: [
           {
             data: [finished, unfinished],
-            backgroundColor: ["#22c55e", "#f1f5f9"], // 完了:緑、未完了:薄いグレー
+            backgroundColor: ["#3474f0", "#e9e8e2"], // 完了:calm、未完了:薄いグレー
             borderWidth: 0,
             hoverBorderWidth: 2,
             hoverBorderColor: "#ffffff",

--- a/app/components/analytics/TagDistribution.vue
+++ b/app/components/analytics/TagDistribution.vue
@@ -30,7 +30,7 @@ const getTagCounts = () => {
         if (!counts[tag.id]) {
           counts[tag.id] = {
             count: 0,
-            color: tag.color || "#3b82f6", // デフォルト色
+            color: tag.color || "#3474f0", // デフォルト色
           };
         }
         counts[tag.id]!.count++;

--- a/app/components/analytics/TimeDistribution.vue
+++ b/app/components/analytics/TimeDistribution.vue
@@ -80,7 +80,7 @@ const initChart = async () => {
           {
             label: "作業時間",
             data: times,
-            backgroundColor: "#60a5fa", // blue-400
+            backgroundColor: "#6d97f4", // calm-400
             borderWidth: 1,
           },
         ],

--- a/app/components/common/Sidebar.vue
+++ b/app/components/common/Sidebar.vue
@@ -61,9 +61,9 @@
           >
             <UButton
               :block="isOpen || isMobile"
-              color="black"
+              color="gray"
               variant="solid"
-              class="justify-center"
+              class="justify-center !bg-gray-900 !text-white hover:!bg-gray-800 dark:!bg-gray-100 dark:!text-gray-900 dark:hover:!bg-gray-200"
               @click="$emit('open-new-task-modal')"
             >
               <UIcon name="i-heroicons-plus" class="w-5 h-5" />

--- a/app/components/common/Sidebar.vue
+++ b/app/components/common/Sidebar.vue
@@ -99,6 +99,49 @@
           </UTooltip>
         </div>
 
+        <!-- テーマ切替 -->
+        <div
+          class="px-3 py-1.5"
+          :class="{ 'text-center': !isOpen && !isMobile }"
+        >
+          <UTooltip
+            :text="!isOpen ? 'テーマ切替' : ''"
+            :ui="{ popper: { strategy: 'fixed' } }"
+            class="w-full"
+          >
+            <UButton
+              :block="isOpen || isMobile"
+              color="gray"
+              variant="ghost"
+              class="justify-start hover:bg-gray-200/60"
+              @click="toggleColorMode"
+            >
+              <ClientOnly>
+                <UIcon
+                  :name="
+                    colorMode.value === 'dark'
+                      ? 'i-heroicons-moon'
+                      : 'i-heroicons-sun'
+                  "
+                  class="w-5 h-5 text-gray-500"
+                />
+                <span v-if="isOpen || isMobile" class="ml-2">
+                  {{ colorMode.value === "dark" ? "ダーク" : "ライト" }}モード
+                </span>
+                <template #fallback>
+                  <UIcon
+                    name="i-heroicons-sun"
+                    class="w-5 h-5 text-gray-500"
+                  />
+                  <span v-if="isOpen || isMobile" class="ml-2">
+                    ライトモード
+                  </span>
+                </template>
+              </ClientOnly>
+            </UButton>
+          </UTooltip>
+        </div>
+
         <!-- 区切り線 -->
         <div class="my-2 border-t border-gray-200" />
 
@@ -402,7 +445,7 @@
               <span
                 v-if="isOpen || isMobile"
                 class="transition-colors duration-200 w-full"
-                :class="isDragOver ? 'text-red-700' : 'text-gray-600'"
+                :class="isDragOver ? 'text-red-700' : 'text-gray-600 dark:text-gray-400'"
               >
                 ドラッグで削除
               </span>
@@ -488,6 +531,16 @@ const { tagStore, newTagName, newTagColor, addTag, deleteTag, updateTag } =
 
 const trashEventBus = useEventBus("trash-drop");
 const isDragOver = ref(false);
+const colorMode = useColorMode();
+
+/**
+ * ライト/ダークモードを切り替える。
+ * @description 現在の実効テーマの反対を preference に設定する。
+ * @returns {void} なし。
+ */
+const toggleColorMode = () => {
+  colorMode.preference = colorMode.value === "dark" ? "light" : "dark";
+};
 const isOpen = ref(true); // サイドバーの開閉状態
 const showTimer = ref(true); // タイマー表示状態
 const showTagModal = ref(false);

--- a/app/components/common/Sidebar.vue
+++ b/app/components/common/Sidebar.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- サイドバー本体 -->
     <div
-      class="fixed top-0 left-0 h-screen bg-white border-r border-gray-200 transition-all duration-300 ease-in-out flex flex-col z-40"
+      class="fixed top-0 left-0 h-screen bg-gray-100 dark:bg-gray-900 border-r border-gray-200/60 dark:border-gray-800 transition-all duration-300 ease-in-out flex flex-col z-40"
       :class="[
         { 'w-64': isOpen || isMobile, 'w-16': !isOpen && !isMobile },
         { '-translate-x-full': !isMobile },
@@ -10,18 +10,22 @@
       ]"
     >
       <!-- ヘッダー部分 -->
-      <div
-        class="flex items-center justify-between p-4 border-b border-gray-200"
-      >
-        <p v-if="isOpen || isMobile" class="font-medium text-gray-900">
-          メニュー
+      <div class="flex items-center justify-between p-4">
+        <p
+          v-if="isOpen || isMobile"
+          class="flex items-center gap-2 font-bold tracking-wide text-gray-900 dark:text-gray-100"
+        >
+          <span
+            class="inline-block h-4 w-4 rounded-md bg-gray-900 dark:bg-gray-100"
+          />
+          タスクボード
         </p>
         <UButton
           v-if="isMobile"
           color="gray"
           variant="ghost"
           size="sm"
-          class="hover:bg-gray-100"
+          class="hover:bg-gray-200/60"
           @click="$emit('close-mobile-menu')"
         >
           <UIcon name="i-heroicons-x-mark" class="h-5 w-5" />
@@ -31,7 +35,7 @@
           color="gray"
           variant="ghost"
           size="sm"
-          class="hover:bg-gray-100"
+          class="hover:bg-gray-200/60"
           @click="toggleSidebar"
         >
           <UIcon
@@ -57,16 +61,13 @@
           >
             <UButton
               :block="isOpen || isMobile"
-              color="gray"
-              variant="ghost"
-              class="justify-start hover:bg-gray-100"
+              color="black"
+              variant="solid"
+              class="justify-center"
               @click="$emit('open-new-task-modal')"
             >
-              <UIcon
-                name="i-heroicons-plus-circle"
-                class="w-5 h-5 text-primary-500"
-              />
-              <span v-if="isOpen || isMobile" class="ml-2">新しいタスク</span>
+              <UIcon name="i-heroicons-plus" class="w-5 h-5" />
+              <span v-if="isOpen || isMobile" class="ml-1">新しいタスク</span>
             </UButton>
           </UTooltip>
         </div>
@@ -83,7 +84,7 @@
               :block="isOpen || isMobile"
               color="gray"
               variant="ghost"
-              class="justify-start hover:bg-gray-100 relative"
+              class="justify-start hover:bg-gray-200/60 relative"
               @click="showTagModal = true"
             >
               <span class="relative inline-block w-5 h-5">
@@ -118,9 +119,14 @@
             >
               <UButton
                 :block="isOpen || isMobile"
-                :color="isCurrentRoute('/board') ? 'primary' : 'gray'"
-                :variant="isCurrentRoute('/board') ? 'soft' : 'ghost'"
-                class="justify-start hover:bg-gray-100"
+                color="gray"
+                variant="ghost"
+                class="justify-start hover:bg-gray-200/60"
+                :class="
+                  isCurrentRoute('/board')
+                    ? 'bg-gray-200/70 dark:bg-gray-800 font-semibold'
+                    : ''
+                "
                 @click="navigateToBoard"
               >
                 <UIcon
@@ -128,7 +134,7 @@
                   class="w-5 h-5"
                   :class="
                     isCurrentRoute('/board')
-                      ? 'text-primary-500'
+                      ? 'text-gray-900 dark:text-gray-100'
                       : 'text-gray-500'
                   "
                 />
@@ -146,9 +152,14 @@
             >
               <UButton
                 :block="isOpen || isMobile"
-                :color="isCurrentRoute('/list') ? 'primary' : 'gray'"
-                :variant="isCurrentRoute('/list') ? 'soft' : 'ghost'"
-                class="justify-start hover:bg-gray-100"
+                color="gray"
+                variant="ghost"
+                class="justify-start hover:bg-gray-200/60"
+                :class="
+                  isCurrentRoute('/list')
+                    ? 'bg-gray-200/70 dark:bg-gray-800 font-semibold'
+                    : ''
+                "
                 @click="navigateTo('/list')"
               >
                 <UIcon
@@ -156,7 +167,7 @@
                   class="w-5 h-5"
                   :class="
                     isCurrentRoute('/list')
-                      ? 'text-primary-500'
+                      ? 'text-gray-900 dark:text-gray-100'
                       : 'text-gray-500'
                   "
                 />
@@ -174,9 +185,14 @@
             >
               <UButton
                 :block="isOpen || isMobile"
-                :color="isCurrentRoute('/analytics') ? 'primary' : 'gray'"
-                :variant="isCurrentRoute('/analytics') ? 'soft' : 'ghost'"
-                class="justify-start hover:bg-gray-100"
+                color="gray"
+                variant="ghost"
+                class="justify-start hover:bg-gray-200/60"
+                :class="
+                  isCurrentRoute('/analytics')
+                    ? 'bg-gray-200/70 dark:bg-gray-800 font-semibold'
+                    : ''
+                "
                 @click="navigateTo('/analytics')"
               >
                 <UIcon
@@ -184,7 +200,7 @@
                   class="w-5 h-5"
                   :class="
                     isCurrentRoute('/analytics')
-                      ? 'text-primary-500'
+                      ? 'text-gray-900 dark:text-gray-100'
                       : 'text-gray-500'
                   "
                 />
@@ -202,9 +218,14 @@
             >
               <UButton
                 :block="isOpen || isMobile"
-                :color="isCurrentRoute('/admin') ? 'primary' : 'gray'"
-                :variant="isCurrentRoute('/admin') ? 'soft' : 'ghost'"
-                class="justify-start hover:bg-gray-100"
+                color="gray"
+                variant="ghost"
+                class="justify-start hover:bg-gray-200/60"
+                :class="
+                  isCurrentRoute('/admin')
+                    ? 'bg-gray-200/70 dark:bg-gray-800 font-semibold'
+                    : ''
+                "
                 @click="navigateTo('/admin')"
               >
                 <UIcon
@@ -212,7 +233,7 @@
                   class="w-5 h-5"
                   :class="
                     isCurrentRoute('/admin')
-                      ? 'text-primary-500'
+                      ? 'text-gray-900 dark:text-gray-100'
                       : 'text-gray-500'
                   "
                 />
@@ -243,7 +264,7 @@
               :color="getFilterButtonColor()"
               :variant="'ghost'"
               :icon="getFilterIcon()"
-              class="justify-start hover:bg-gray-100"
+              class="justify-start hover:bg-gray-200/60"
               @click="toggleTaskFilter"
             >
               <span v-if="isOpen || isMobile" class="ml-2">{{
@@ -266,15 +287,15 @@
           >
             <UButton
               :block="isOpen || isMobile"
-              :color="showTagBar ? 'green' : 'gray'"
+              :color="showTagBar ? 'primary' : 'gray'"
               :variant="'ghost'"
-              class="justify-start hover:bg-gray-100"
+              class="justify-start hover:bg-gray-200/60"
               @click="toggleTagVisibility"
             >
               <UIcon
                 name="i-heroicons-tag"
                 class="w-5 h-5"
-                :class="showTagBar ? 'text-green-500' : 'text-gray-400'"
+                :class="showTagBar ? 'text-calm-500' : 'text-gray-400'"
               />
               <span v-if="isOpen || isMobile" class="ml-2">
                 {{ showTagBar ? "タグ表示中" : "タグ非表示" }}
@@ -298,14 +319,14 @@
           >
             <UButton
               :block="isOpen || isMobile"
-              :color="showTimer ? 'green' : 'gray'"
+              :color="showTimer ? 'primary' : 'gray'"
               :variant="'ghost'"
-              class="justify-start hover:bg-gray-100"
+              class="justify-start hover:bg-gray-200/60"
               @click="toggleTimerVisibility"
             >
               <UIcon
                 name="i-heroicons-clock"
-                :class="showTimer ? 'text-green-500' : 'text-gray-400'"
+                :class="showTimer ? 'text-calm-500' : 'text-gray-400'"
                 class="w-5 h-5"
               />
               <span v-if="isOpen || isMobile" class="ml-2">
@@ -333,15 +354,15 @@
           >
             <UButton
               :block="isOpen || isMobile"
-              :color="showCompletedTasks ? 'green' : 'gray'"
+              :color="showCompletedTasks ? 'primary' : 'gray'"
               :variant="'ghost'"
-              class="justify-start hover:bg-gray-100"
+              class="justify-start hover:bg-gray-200/60"
               @click="toggleCompletedTasksVisibility"
             >
               <UIcon
                 name="i-heroicons-check-circle"
                 class="w-5 h-5"
-                :class="showCompletedTasks ? 'text-green-500' : 'text-gray-400'"
+                :class="showCompletedTasks ? 'text-calm-500' : 'text-gray-400'"
               />
               <span v-if="isOpen || isMobile" class="ml-2">
                 {{
@@ -390,7 +411,9 @@
         </div>
 
         <!-- タスク数表示 -->
-        <div class="px-4 py-3 text-center border-t border-gray-200 bg-gray-50">
+        <div
+          class="px-4 py-3 text-center border-t border-gray-200 dark:border-gray-800"
+        >
           <UTooltip
             :text="!isOpen ? `アイテム数: ${totalItemCount}/100` : ''"
             :ui="{ popper: { strategy: 'fixed' } }"
@@ -699,9 +722,9 @@ const getFilterIcon = () => {
 const getFilterButtonColor = () => {
   switch (todoStore.taskFilter) {
     case "all":
-      return "green";
+      return "primary";
     case "private":
-      return "green";
+      return "primary";
     case "public":
       return "gray";
     default:

--- a/app/components/kanban/TaskBoard.vue
+++ b/app/components/kanban/TaskBoard.vue
@@ -4,7 +4,7 @@
     <Transition name="slide">
       <div
         v-if="currentTimingTodo && showTimerBar"
-        class="mb-6 p-4 bg-blue-50/50 rounded-[6px] border border-blue-100 flex flex-col md:flex-row gap-4 items-center justify-between"
+        class="mb-6 p-4 bg-calm-50 dark:bg-calm-950/40 rounded-card ring-1 ring-calm-200 dark:ring-calm-900 flex flex-col md:flex-row gap-4 items-center justify-between"
       >
         <div class="flex flex-col md:flex-row items-center gap-3">
           <!-- アナログ時計風タイマー -->
@@ -16,10 +16,11 @@
           </div>
         </div>
         <UButton
-          color="green"
+          color="gray"
           variant="solid"
           size="sm"
           icon="i-heroicons-pause"
+          class="!bg-gray-900 !text-white hover:!bg-gray-800 dark:!bg-gray-100 dark:!text-gray-900 dark:hover:!bg-gray-200"
           @click="stopTiming(currentTimingTodo)"
         >
           停止
@@ -72,12 +73,12 @@
       <!-- Priority -->
       <div :class="getPriorityClass()">
         <div
-          class="rounded-[6px] p-4 h-full flex flex-col shadow-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900"
+          class="rounded-xl p-1 h-full flex flex-col"
         >
           <div
-            class="mb-4 flex items-center justify-between gap-2 text-gray-900 dark:text-gray-100"
+            class="mb-3 px-1 flex items-center justify-between gap-2 text-gray-500 dark:text-gray-400"
           >
-            <div class="flex items-center gap-2 font-medium">
+            <div class="flex items-center gap-2 text-[13px] font-semibold tracking-wide">
               <UIcon
                 :name="STATUS_COLORS[TASK_STATUS.PRIORITY].iconName"
                 class="w-5 h-5"
@@ -113,7 +114,7 @@
               drag-class="drag-item"
               chosen-class="chosen-item"
               :class="{
-                'border-2 border-dashed border-gray-200 rounded-[6px] p-4':
+                'border border-dashed border-gray-300 dark:border-gray-700 rounded-lg p-4':
                   todosByStatus[TASK_STATUS.PRIORITY].length === 0,
               }"
               @change="handleDragChange"
@@ -134,7 +135,7 @@
               <template #footer>
                 <div
                   v-if="todosByStatus[TASK_STATUS.PRIORITY].length === 0"
-                  class="text-gray-500 text-sm text-center"
+                  class="text-gray-400 text-sm text-center py-4"
                 >
                   タスクがありません
                 </div>
@@ -147,12 +148,12 @@
       <!-- Next Up -->
       <div :class="getNextUpClass()">
         <div
-          class="rounded-[6px] p-4 h-full shadow-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900"
+          class="rounded-xl p-1 h-full"
         >
           <div
-            class="mb-4 flex items-center justify-between gap-2 text-gray-900 dark:text-gray-100"
+            class="mb-3 px-1 flex items-center justify-between gap-2 text-gray-500 dark:text-gray-400"
           >
-            <div class="flex items-center gap-2 font-medium">
+            <div class="flex items-center gap-2 text-[13px] font-semibold tracking-wide">
               <UIcon
                 :name="STATUS_COLORS[TASK_STATUS.NEXT].iconName"
                 class="w-5 h-5"
@@ -204,7 +205,7 @@
           </draggable>
           <div
             v-if="todosByStatus[TASK_STATUS.NEXT].length === 0"
-            class="text-gray-500 text-sm text-center mt-2"
+            class="text-gray-400 text-sm text-center py-4"
           >
             タスクがありません
           </div>
@@ -216,10 +217,10 @@
     <div class="block md:hidden space-y-4">
       <!-- Priority -->
       <div
-        class="rounded-[6px] p-4 shadow-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900"
+        class="rounded-xl p-1"
       >
         <h2
-          class="mb-4 font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2"
+          class="mb-3 px-1 text-[13px] font-semibold tracking-wide text-gray-500 dark:text-gray-400 flex items-center gap-2"
         >
           <UIcon
             :name="STATUS_COLORS[TASK_STATUS.PRIORITY].iconName"
@@ -257,7 +258,7 @@
         </draggable>
         <div
           v-if="todosByStatus[TASK_STATUS.PRIORITY].length === 0"
-          class="text-gray-500 text-sm text-center mt-2"
+          class="text-gray-400 text-sm text-center py-4"
         >
           タスクがありません
         </div>
@@ -265,10 +266,10 @@
 
       <!-- Next Up -->
       <div
-        class="rounded-[6px] p-4 shadow-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900"
+        class="rounded-xl p-1"
       >
         <h2
-          class="mb-4 font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2"
+          class="mb-3 px-1 text-[13px] font-semibold tracking-wide text-gray-500 dark:text-gray-400 flex items-center gap-2"
         >
           <UIcon
             :name="STATUS_COLORS[TASK_STATUS.NEXT].iconName"
@@ -306,7 +307,7 @@
         </draggable>
         <div
           v-if="todosByStatus[TASK_STATUS.NEXT].length === 0"
-          class="text-gray-500 text-sm text-center mt-2"
+          class="text-gray-400 text-sm text-center py-4"
         >
           タスクがありません
         </div>
@@ -315,10 +316,10 @@
 
     <!-- PC/モバイル共通: 下段：Archived -->
     <div
-      class="rounded-[6px] p-4 mt-4 shadow-md border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900"
+      class="rounded-xl p-1 mt-6"
     >
       <h2
-        class="mb-4 font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2"
+        class="mb-3 px-1 text-[13px] font-semibold tracking-wide text-gray-500 dark:text-gray-400 flex items-center gap-2"
       >
         <UIcon
           :name="STATUS_COLORS[TASK_STATUS.ARCHIVED].iconName"
@@ -356,7 +357,7 @@
       </draggable>
       <div
         v-if="todosByStatus[TASK_STATUS.ARCHIVED].length === 0"
-        class="text-gray-500 text-sm text-center mt-2"
+        class="text-gray-400 text-sm text-center py-4"
       >
         タスクがありません
       </div>
@@ -1962,15 +1963,15 @@ const getLayoutIcon = () => {
 
 /* ドラッグ＆ドロップ関連のスタイル */
 .ghost-card {
-  background-color: #f3f4f6;
-  border: 1px dashed #d1d5db;
+  background-color: var(--app-side);
+  border: 1px dashed var(--app-line);
   opacity: 0.6;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+  box-shadow: none;
 }
 
 .drag-item {
-  opacity: 0.8;
-  transform: rotate(2deg);
+  opacity: 0.85;
+  transform: rotate(1deg);
 }
 
 .chosen-item {

--- a/app/components/kanban/TodoCard.vue
+++ b/app/components/kanban/TodoCard.vue
@@ -1,11 +1,9 @@
 <template>
   <div
-    class="group bg-white rounded-[6px] p-4 hover:shadow-md transition-all duration-200 relative"
+    class="group bg-white dark:bg-gray-800 rounded-card p-4 shadow-card hover:shadow-card-hover hover:-translate-y-px transition-all duration-200 relative"
     :class="[
       { 'opacity-50 grayscale': todo.is_finished },
-      todo.is_timing
-        ? 'bg-blue-100 border border-blue-500'
-        : 'border border-gray-200',
+      todo.is_timing ? 'ring-1 ring-calm-400 bg-calm-50 dark:bg-calm-950' : '',
     ]"
     draggable="true"
     :data-status="todo.status"
@@ -52,16 +50,16 @@
             v-for="tag in todo.tags"
             :key="tag.id"
             :style="{
-              backgroundColor: `${tag.color}15`,
-              color: tag.color || '#3b82f6',
+              backgroundColor: 'transparent',
+              color: tag.color || '#3474f0',
+              boxShadow: `inset 0 0 0 1px ${tag.color || '#3474f0'}55`,
               border: 'none',
-              fontWeight: '500',
-              fontSize: '0.75rem',
-              borderRadius: '0.375rem',
-              padding: '0.25rem 0.5rem',
+              fontWeight: '600',
+              fontSize: '0.6875rem',
+              borderRadius: '999px',
+              padding: '0.2rem 0.55rem',
               lineHeight: '1',
             }"
-            class="transition-all duration-200 hover:bg-opacity-25"
           >
             {{ tag.name }}
           </UBadge>
@@ -101,8 +99,12 @@
 
     <!-- タイマー表示 -->
     <div v-if="showTimerBar" class="flex items-center justify-between">
-      <div class="flex items-center text-sm text-gray-500">
-        <UIcon name="i-heroicons-clock" class="w-4 h-4 mr-1.5" />
+      <div class="flex items-center text-sm text-gray-500 tnum">
+        <UIcon
+          name="i-heroicons-clock"
+          class="w-4 h-4 mr-1.5"
+          :class="{ 'text-calm-500': todo.is_timing }"
+        />
         {{ todo.is_timing ? "計測中..." : formatTime(todo.total_time || 0) }}
       </div>
 
@@ -135,7 +137,7 @@
     <!-- eslint-disable vue/no-v-html -->
     <div
       v-if="todo.memo"
-      class="border border-gray-200/50 rounded-[6px] p-2 mt-2 text-sm markdown-prose max-h-[20em] w-full overflow-y-auto pr-2 break-all"
+      class="rounded-lg p-2 mt-2 text-sm markdown-prose max-h-[20em] w-full overflow-y-auto pr-2 break-all"
       v-html="parsedMemo"
     />
     <!-- eslint-enable vue/no-v-html -->

--- a/app/components/kanban/TodoCard.vue
+++ b/app/components/kanban/TodoCard.vue
@@ -21,7 +21,7 @@
           />
           <NuxtLink
             :to="`/note/${todo.id}`"
-            class="font-medium text-gray-900 truncate hover:text-primary-600 hover:underline transition-colors"
+            class="font-medium text-gray-900 dark:text-gray-100 truncate hover:text-primary-600 dark:hover:text-primary-400 hover:underline transition-colors"
           >
             {{ todo.title }}
           </NuxtLink>

--- a/app/components/kanban/TodoCard.vue
+++ b/app/components/kanban/TodoCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="group bg-white dark:bg-gray-800 rounded-card p-4 shadow-card hover:shadow-card-hover hover:-translate-y-px transition-all duration-200 relative"
+    class="group card-in bg-white dark:bg-gray-800 rounded-card p-4 shadow-card hover:shadow-card-hover hover:-translate-y-px transition-all duration-200 relative"
     :class="[
       { 'opacity-50 grayscale': todo.is_finished },
       todo.is_timing ? 'ring-1 ring-calm-400 bg-calm-50 dark:bg-calm-950' : '',
@@ -103,7 +103,7 @@
         <UIcon
           name="i-heroicons-clock"
           class="w-4 h-4 mr-1.5"
-          :class="{ 'text-calm-500': todo.is_timing }"
+          :class="{ 'text-calm-500 pulse-soft': todo.is_timing }"
         />
         {{ todo.is_timing ? "計測中..." : formatTime(todo.total_time || 0) }}
       </div>

--- a/app/components/list/TableHeader.vue
+++ b/app/components/list/TableHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <thead class="bg-gray-50">
+  <thead class="bg-gray-50 dark:bg-gray-900/60">
     <tr>
       <!-- <th class="w-8 px-2 py-3 text-center align-middle">
         <UIcon

--- a/app/components/list/TableRow.vue
+++ b/app/components/list/TableRow.vue
@@ -116,7 +116,7 @@
         <UIcon name="i-heroicons-lock-closed" class="w-4 h-4 mr-1" />
         プライベート
       </span>
-      <span v-else class="text-blue-600 flex items-center">
+      <span v-else class="text-calm-600 flex items-center">
         <UIcon name="i-heroicons-eye" class="w-4 h-4 mr-1" />
         パブリック
       </span>
@@ -219,8 +219,11 @@
         <span
           v-for="tag in todo.tags"
           :key="tag.id"
-          class="px-2 py-0.5 text-xs rounded-full text-white"
-          :style="{ backgroundColor: tag.color }"
+          class="px-2 py-0.5 text-[11px] font-semibold rounded-full"
+          :style="{
+            color: tag.color || '#3474f0',
+            boxShadow: `inset 0 0 0 1px ${tag.color || '#3474f0'}55`,
+          }"
         >
           {{ tag.name }}
         </span>

--- a/app/components/list/table.vue
+++ b/app/components/list/table.vue
@@ -9,7 +9,7 @@
     />
 
     <!-- メインテーブル -->
-    <div class="rounded-[6px] border overflow-hidden">
+    <div class="rounded-card shadow-card bg-white dark:bg-gray-800 overflow-hidden">
       <div class="overflow-x-auto">
         <table class="w-full whitespace-nowrap">
           <TableHeader
@@ -24,7 +24,7 @@
             tag="tbody"
             handle=".handle"
             :animation="200"
-            class="bg-white divide-y divide-gray-200"
+            class="bg-white dark:bg-gray-800 divide-y divide-gray-100 dark:divide-gray-800"
             :group="{ name: 'todos', pull: true, put: true }"
             item-key="id"
             ghost-class="ghost-card"

--- a/app/components/modals/HelpModal.vue
+++ b/app/components/modals/HelpModal.vue
@@ -12,7 +12,7 @@
             <li class="flex items-start">
               <UIcon
                 name="i-heroicons-plus-circle"
-                class="mr-2 text-blue-500 flex-shrink-0 mt-1"
+                class="mr-2 text-calm-500 flex-shrink-0 mt-1"
               />
               <span
                 >Priority / Next
@@ -22,7 +22,7 @@
             <li class="flex items-start">
               <UIcon
                 name="i-heroicons-pencil-square"
-                class="mr-2 text-blue-500 flex-shrink-0 mt-1"
+                class="mr-2 text-calm-500 flex-shrink-0 mt-1"
               />
               <span
                 >カード右上の編集ボタンでタスク内容を即時更新できます。変更は自動保存されます。</span
@@ -77,7 +77,7 @@
             <li class="flex items-start">
               <UIcon
                 name="i-heroicons-view-columns"
-                class="mr-2 text-blue-500 flex-shrink-0 mt-1"
+                class="mr-2 text-calm-500 flex-shrink-0 mt-1"
               />
               <span
                 >PC ではレイアウト切り替えボタンから Priority と Next を並列 /
@@ -96,7 +96,7 @@
             <li class="flex items-start">
               <UIcon
                 name="i-heroicons-clock"
-                class="mr-2 text-blue-600 flex-shrink-0 mt-1"
+                class="mr-2 text-calm-600 flex-shrink-0 mt-1"
               />
               <span
                 >カードの再生 /
@@ -242,7 +242,7 @@
                     [リンク](https://example.com)
                   </td>
                   <td class="py-2 border-b border-gray-200">
-                    <a href="#" class="text-blue-600 underline">リンク</a>
+                    <a href="#" class="text-calm-600 underline">リンク</a>
                   </td>
                 </tr>
                 <tr>

--- a/app/components/modals/TaskEditModal.vue
+++ b/app/components/modals/TaskEditModal.vue
@@ -98,7 +98,7 @@
             >
               <UIcon
                 name="i-heroicons-information-circle"
-                class="text-blue-500"
+                class="text-calm-500"
               />
             </UTooltip>
           </div>

--- a/app/components/note/AssetManager.vue
+++ b/app/components/note/AssetManager.vue
@@ -541,7 +541,7 @@ const detectEncoding = (bytes: Uint8Array, asset: TodoAsset): string => {
   if (mime === "text/html" || mime === "application/xhtml+xml") {
     const head = new TextDecoder("ascii").decode(bytes.slice(0, 2048));
     const charsetMatch = head.match(
-      /charset\s*=\s*["']?\s*([\w\-]+)/i,
+      /charset\s*=\s*["']?\s*([\w-]+)/i,
     );
     if (charsetMatch) {
       return charsetMatch[1].toLowerCase();

--- a/app/components/note/index.vue
+++ b/app/components/note/index.vue
@@ -43,7 +43,7 @@
         <div class="flex gap-3">
           <UButton
             v-if="!isTimerRunning"
-            color="green"
+            color="primary"
             :disabled="isTaskCompleted"
             class="px-4"
             @click="startTimer"
@@ -51,7 +51,13 @@
             <UIcon name="i-heroicons-play" class="mr-1" />
             開始
           </UButton>
-          <UButton v-else color="amber" class="px-4" @click="stopTimer">
+          <UButton
+            v-else
+            color="gray"
+            variant="solid"
+            class="px-4 !bg-gray-900 !text-white hover:!bg-gray-800 dark:!bg-gray-100 dark:!text-gray-900 dark:hover:!bg-gray-200"
+            @click="stopTimer"
+          >
             <UIcon name="i-heroicons-pause" class="mr-1" />
             停止
           </UButton>
@@ -77,7 +83,7 @@
         <input
           v-model="editedTask.title"
           type="text"
-          class="w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring focus:ring-primary-200"
+          class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:border-calm-400 focus:ring-2 focus:ring-calm-100 dark:focus:ring-calm-900"
           @change="updateTask('title')"
         >
       </div>
@@ -90,7 +96,7 @@
           >
           <select
             v-model="editedTask.status"
-            class="w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring focus:ring-primary-200"
+            class="w-full px-4 py-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:border-calm-400 focus:ring-2 focus:ring-calm-100 dark:focus:ring-calm-900"
             @change="updateTask('status')"
           >
             <option
@@ -154,14 +160,14 @@
       <div v-if="memoViewMode === 'edit'" class="mt-4">
         <textarea
           v-model="editedTask.memo"
-          class="w-full h-[500px] px-4 py-3 border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring focus:ring-primary-200 font-mono text-sm"
+          class="w-full h-[500px] px-4 py-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:border-calm-400 focus:ring-2 focus:ring-calm-100 dark:focus:ring-calm-900 font-mono text-sm"
           placeholder="Markdownでメモを入力できます..."
           @change="updateTask('memo')"
         />
       </div>
       <div
         v-else
-        class="mt-4 bg-white border border-green-200 p-6 rounded-lg overflow-auto max-h-[90vh]"
+        class="mt-4 bg-white dark:bg-gray-800 shadow-card p-6 rounded-card overflow-auto max-h-[90vh]"
       >
         <!-- eslint-disable vue/no-v-html -->
         <div class="markdown-prose" v-html="renderedMarkdown" />

--- a/app/components/note/index.vue
+++ b/app/components/note/index.vue
@@ -37,9 +37,9 @@
     </div>
 
     <!-- タイマー部分 - 上部に固定 -->
-    <div class="mb-6 bg-gray-50 p-4 rounded-lg shadow-sm">
+    <div class="mb-6 bg-gray-100 dark:bg-gray-900 p-4 rounded-card">
       <div class="flex items-center justify-between">
-        <h3 class="text-lg font-medium text-gray-700">経過時間</h3>
+        <h3 class="text-lg font-medium text-gray-700 dark:text-gray-300">経過時間</h3>
         <div class="flex gap-3">
           <UButton
             v-if="!isTimerRunning"
@@ -77,7 +77,7 @@
     <div class="mb-6">
       <!-- タイトル編集 -->
       <div class="mb-4">
-        <label class="block text-sm font-medium text-gray-700 mb-1"
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
           >タイトル</label
         >
         <input
@@ -91,7 +91,7 @@
       <!-- ステータスと完了フラグ -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
             >ステータス</label
           >
           <select
@@ -109,7 +109,7 @@
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1"
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
             >完了</label
           >
           <div class="flex items-center h-[42px]">
@@ -135,7 +135,7 @@
 
     <!-- メモ (Markdown) -->
     <div class="mb-6">
-      <label class="block text-sm font-medium text-gray-700 mb-3">メモ</label>
+      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">メモ</label>
       <div class="flex gap-2">
         <UButton
           :color="memoViewMode === 'edit' ? 'primary' : 'gray'"

--- a/app/layouts/board.vue
+++ b/app/layouts/board.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-gray-100/20">
+  <div class="min-h-screen">
     <!-- クライアントサイドでのみ評価される loading 状態 -->
     <ClientOnly>
       <div

--- a/app/pages/analytics/index.vue
+++ b/app/pages/analytics/index.vue
@@ -5,7 +5,7 @@
       <!-- 期間フィルター -->
       <select
         v-model="selectedPeriod"
-        class="w-40 rounded-[6px] border border-gray-300 appearance-none px-3 py-2 focus:border-primary-500 focus:outline-none"
+        class="w-40 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 appearance-none px-3 py-2 focus:border-calm-400 focus:outline-none focus:ring-2 focus:ring-calm-100 dark:focus:ring-calm-900"
       >
         <option value="today">今日</option>
         <option value="7days">過去7日間</option>
@@ -13,14 +13,14 @@
         <option value="all">すべて</option>
       </select>
     </div>
-    <UCard class="mb-6 rounded-[6px]">
+    <UCard class="mb-6">
       <template #header>
-        <div class="flex justify-between items-center rounded-[6px]">
+        <div class="flex justify-between items-center">
           <h2 class="text-xl font-bold">集計サマリー</h2>
         </div>
       </template>
       <div class="analytics-summary grid grid-cols-1 md:grid-cols-3 gap-4">
-        <UCard class="rounded-[6px]">
+        <UCard>
           <div class="text-center">
             <div class="text-2xl font-bold text-primary-600">
               {{ totalTasks }}
@@ -28,11 +28,11 @@
             <div class="text-sm text-gray-500">実施タスク数</div>
           </div>
         </UCard>
-        <UCard class="rounded-[6px]">
+        <UCard>
           <div class="text-center">
             <div
               v-if="showCompletedTasks"
-              class="text-2xl font-bold text-green-600"
+              class="text-2xl font-bold text-calm-600"
             >
               {{ completedTasks }}
             </div>
@@ -40,9 +40,9 @@
             <div class="text-sm text-gray-500">完了タスク数</div>
           </div>
         </UCard>
-        <UCard class="rounded-[6px]">
+        <UCard>
           <div class="text-center">
-            <div class="text-2xl font-bold text-yellow-600">
+            <div class="text-2xl font-bold text-gray-800 dark:text-gray-200 tnum">
               {{ formatTime(totalTimeSpent) }}
             </div>
             <div class="text-sm text-gray-500">合計作業時間</div>
@@ -52,7 +52,7 @@
     </UCard>
 
     <!-- タスクステータス分布 -->
-    <UCard class="mb-6 rounded-[6px]">
+    <UCard class="mb-6">
       <template #header>
         <h3 class="text-lg font-bold">ステータス別タスク分布</h3>
       </template>
@@ -61,7 +61,7 @@
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
       <!-- タスク時間分析 -->
-      <UCard class="rounded-[6px]">
+      <UCard>
         <template #header>
           <h3 class="text-lg font-bold">タスク時間分析</h3>
         </template>
@@ -71,7 +71,7 @@
       </UCard>
 
       <!-- タグ別タスク分布 -->
-      <UCard class="rounded-[6px]">
+      <UCard>
         <template #header>
           <h3 class="text-lg font-bold">タグ別タスク分布</h3>
         </template>
@@ -82,13 +82,13 @@
     </div>
 
     <!-- 最近のアクティビティ -->
-    <UCard class="rounded-[6px]">
+    <UCard>
       <template #header>
         <h3 class="text-lg font-bold">最近のアクティビティ</h3>
       </template>
       <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
+          <thead class="bg-gray-50 dark:bg-gray-900/60">
             <tr>
               <th
                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
@@ -112,11 +112,11 @@
               </th>
             </tr>
           </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-100 dark:divide-gray-800">
             <tr v-for="task in recentTasks" :key="task.id">
               <td class="px-6 py-4 whitespace-nowrap">
                 <div
-                  class="text-sm font-medium text-gray-900 flex items-center"
+                  class="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center"
                 >
                   <NuxtLink
                     :to="`/note/${task.id}`"

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -38,19 +38,19 @@ export const DB_STATUS_MAPPING = {
 export const STATUS_COLORS = {
   [TASK_STATUS.PRIORITY]: {
     bg: "bg-white/80",
-    border: "border border-green-300",
+    border: "border border-rose-200",
     icon: "text-rose-400",
     iconName: "i-heroicons-inbox",
   },
   [TASK_STATUS.NEXT]: {
     bg: "bg-white/80",
-    border: "border border-blue-300",
+    border: "border border-calm-200",
     icon: "text-calm-500",
     iconName: "i-heroicons-clock",
   },
   [TASK_STATUS.ARCHIVED]: {
     bg: "bg-white/80",
-    border: "border border-gray-300",
+    border: "border border-gray-200",
     icon: "text-gray-400",
     iconName: "i-heroicons-check-circle",
   },

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -39,19 +39,19 @@ export const STATUS_COLORS = {
   [TASK_STATUS.PRIORITY]: {
     bg: "bg-white/80",
     border: "border border-green-300",
-    icon: "text-green-500",
+    icon: "text-rose-400",
     iconName: "i-heroicons-inbox",
   },
   [TASK_STATUS.NEXT]: {
     bg: "bg-white/80",
     border: "border border-blue-300",
-    icon: "text-blue-500",
+    icon: "text-calm-500",
     iconName: "i-heroicons-clock",
   },
   [TASK_STATUS.ARCHIVED]: {
     bg: "bg-white/80",
     border: "border border-gray-300",
-    icon: "text-gray-500",
+    icon: "text-gray-400",
     iconName: "i-heroicons-check-circle",
   },
 } as const;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,76 +2,55 @@ import type { Config } from "tailwindcss";
 import animate from "tailwindcss-animate";
 import typography from "@tailwindcss/typography";
 
+/**
+ * デザイントークン: カーム・ミニマル (issue #112)
+ * - calm: アクセントの青。Nuxt UI の primary に接続される (app/app.config.ts)
+ * - gray: 紙のような暖色寄りグレー。既存の gray-* 直書きクラスごと世界観を差し替える
+ * 実行時に切り替わる値 (ダークモード等) は app/assets/css/main.css の CSS 変数側で管理する
+ */
 export default {
   darkMode: ["class"],
   content: [
-    "./pages/**/*.{ts,tsx}",
-    "./components/**/*.{ts,tsx}",
-    "./app/**/*.{ts,tsx}",
-    "./src/**/*.{ts,tsx}",
+    "./app/**/*.{vue,ts,tsx}",
+    "./stores/**/*.ts",
   ],
   theme: {
     extend: {
-      borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
-      },
       colors: {
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+        calm: {
+          50: "#EFF4FE",
+          100: "#DEE9FD",
+          200: "#C3D6FB",
+          300: "#9CBAF8",
+          400: "#6D97F4",
+          500: "#3474F0",
+          600: "#2A5FD1",
+          700: "#234EAC",
+          800: "#1F4189",
+          900: "#1D3970",
+          950: "#14264C",
         },
-        popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
-        },
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        chart: {
-          1: "hsl(var(--chart-1))",
-          2: "hsl(var(--chart-2))",
-          3: "hsl(var(--chart-3))",
-          4: "hsl(var(--chart-4))",
-          5: "hsl(var(--chart-5))",
+        gray: {
+          50: "#F8F8F6",
+          100: "#F1F1ED",
+          200: "#E9E8E2",
+          300: "#D8D7D0",
+          400: "#AEADA5",
+          500: "#8E8D85",
+          600: "#6E6D66",
+          700: "#56554F",
+          800: "#3B3A36",
+          900: "#262521",
+          950: "#191814",
         },
       },
-      keyframes: {
-        "accordion-down": {
-          from: { height: "0" },
-          to: { height: "var(--radix-accordion-content-height)" },
-        },
-        "accordion-up": {
-          from: { height: "var(--radix-accordion-content-height)" },
-          to: { height: "0" },
-        },
+      boxShadow: {
+        card: "0 1px 2px rgb(24 26 34 / 0.05), 0 0 0 1px rgb(24 26 34 / 0.04)",
+        "card-hover":
+          "0 6px 18px rgb(24 26 34 / 0.09), 0 0 0 1px rgb(24 26 34 / 0.05)",
       },
-      animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
+      borderRadius: {
+        card: "10px",
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,7 +30,9 @@ export default {
           900: "#1D3970",
           950: "#14264C",
         },
-        gray: {
+        // Nuxt UI が gray をエイリアスするため、直接 colors.gray を上書きせず
+        // 独自名 paper で定義して app.config.ts の ui.gray から参照する
+        paper: {
           50: "#F8F8F6",
           100: "#F1F1ED",
           200: "#E9E8E2",


### PR DESCRIPTION
## 概要

UI 全体をカーム・ミニマル方向（白ベース + 青1アクセント、Things 3 系の静けさ）に刷新する。機能・DB・ルーティングは一切変更していない。比較モックで採用決定済みの A案を、デザイントークン基盤の上に画面単位で適用した。

## 変更内容（フェーズ = コミット単位）

- **P0 トークン基盤**: calm(青) / paper(暖色グレー) パレットを定義し、`app.config.ts` で Nuxt UI に接続。shadcn 残骸の削除で壊れていた `rounded-lg` 系も復旧
- **P1 共通シェル**: サイドバーを淡い側面 + 黒地の新規タスクボタンに。トグルON色を緑→calm青へ統一
- **P2 ボード**: カードを「枠線なし・影1枚・ホバーで浮く」に。カラム白箱を撤去し、タグをアウトラインピルに
- **P3 リスト・詳細・Markdown**: Solarized風 + 明朝見出しのMarkdownスタイルを全面書き直し（全てCSS変数参照）。入力欄を calm フォーカスリングに
- **P4 アナリティクス・ダークモード**: チャート配色を calm 系に統一。サイドバーにテーマ切替を追加し、dark: 欠けを補完
- **P5 マイクロインタラクション**: チェック時のポップ、計測中の脈動、カード出現アニメ、reduced-motion 対応

修正コミット: Nuxt UI の gray エイリアスと衝突して gray-* が全滅する問題の対処、main 由来 lint エラー1件の解消を含む。

## 確認方法

- [ ] `/board` `/list` `/note/[id]` `/analytics` の見た目が紙背景 + 白カード + 青アクセントで統一されていること
- [ ] サイドバーのテーマ切替でダークモードになり、文字が読めない箇所がないこと
- [ ] タイマー開始/停止、タスク作成・編集・削除、D&D が従来どおり動作すること（機能は無変更）
- [ ] `npm run lint`（全緑）/ `npm run build` 通過確認済み
- [ ] Playwright 実画面確認済み（ボード/リスト/詳細、ライト/ダーク）

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)